### PR TITLE
Add applicative instance

### DIFF
--- a/src/Control/Monad/Free.purs.hs
+++ b/src/Control/Monad/Free.purs.hs
@@ -12,6 +12,10 @@ instance functorFree :: (Functor f) => Functor (Free f) where
   (<$>) f = go where
     go (Pure a)  = Pure (f a)
     go (Free fa) = Free (go <$> fa)
+    
+instance applicativeFree :: (Functor f) => Applicative (Free f) where
+  pure = return
+  (<*>) = ap
 
 instance monadFree :: (Functor f) => Monad (Free f) where
   return = Pure


### PR DESCRIPTION
This is just the lazy definition for it, but when the addition of superclasses gets merged there will need to be an `Applicative (Free f)` instance to satisfy `Monad (Free f)`
