### PR TITLE
update to compatible transformers version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "purescript-control": "~0.2.1",
     "purescript-either": "~0.1.3",
     "purescript-exists": "*",
-    "purescript-transformers": "~0.2.0",
+    "purescript-transformers": "~0.2.1",
     "purescript-lazy": "~0.1.0",
     "purescript-foldable-traversable": "~0.1.3"
   }


### PR DESCRIPTION
A number of other libs have moved onto 0.2.1 of transformers, so I updated this one to avoid version conflicts.
