### PR TITLE
Partially apply FreeC

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
       Free :: f (Free f a) -> Free f a
       Gosub :: (forall s. (forall r. (Unit -> Free f r) -> (r -> Free f a) -> s) -> s) -> Free f a
 
-    type FreeC f a = Free (Coyoneda f) a
+    type FreeC f = Free (Coyoneda f)
 
 
 ### Type Classes

--- a/examples/TeletypeCoproduct.purs
+++ b/examples/TeletypeCoproduct.purs
@@ -57,9 +57,9 @@ teletype3N :: forall e. Natural Teletype3F (Eff (trace :: Trace | e))
 teletype3N (Print3 s a) = const a <$> trace ("teletype3: " ++ s)
 
 tN :: forall e. Natural TF (Eff (trace :: Trace | e))
-tN fa = fromJust$ (teletype1N <$> prj fa) <|>
-                  (teletype2N <$> prj fa) <|>
-                  (teletype3N <$> prj fa)
+tN fa = fromJust $ (teletype1N <$> prj fa) <|>
+                   (teletype2N <$> prj fa) <|>
+                   (teletype3N <$> prj fa)
 
 run :: forall a. T a -> Eff (trace :: Trace) a
 run = goEffC tN

--- a/src/Control/Monad/Free.purs
+++ b/src/Control/Monad/Free.purs
@@ -22,7 +22,7 @@ data Free f a = Pure a
               | Free (f (Free f a))
               | Gosub (forall s. (forall r. (Unit -> Free f r) -> (r -> Free f a) -> s) -> s)
 
-type FreeC f a = Free (Coyoneda f) a
+type FreeC f = Free (Coyoneda f)
 
 class MonadFree f m where
   wrap :: forall a. f (m a) -> m a


### PR DESCRIPTION
I am not sure if this is the best option, but making this change allows types defined using `FreeC` to be passed as a type parameter to something like `Natural`. For example, it allows for defining the natural transformation [todomvcN](https://github.com/purescript-contrib/purescript-angular/blob/b459f8b6a8ab3531591481dca9c62c57b7f86724/examples/TodomvcF/TodomvcI.purs#L38).
