### PR TITLE
Add MonadEff instance

### DIFF
--- a/src/Control/Monad/Free.purs
+++ b/src/Control/Monad/Free.purs
@@ -12,8 +12,9 @@ module Control.Monad.Free
 
 import Prelude
 
+import Control.Monad.Eff.Class (MonadEff, liftEff)
 import Control.Monad.Rec.Class (MonadRec, tailRecM)
-import Control.Monad.Trans (MonadTrans)
+import Control.Monad.Trans (MonadTrans, lift)
 
 import Data.CatList (CatList(), empty, snoc, uncons)
 import Data.Either (Either(..), either)
@@ -61,6 +62,9 @@ instance freeMonadTrans :: MonadTrans Free where
 
 instance freeMonadRec :: MonadRec (Free f) where
   tailRecM k a = k a >>= either (tailRecM k) pure
+
+instance freeMonadEff :: (MonadEff eff f) => MonadEff eff (Free f) where
+  liftEff = lift <<< liftEff
 
 -- | Lift an impure value described by the generating type constructor `f` into the free monad.
 liftF :: forall f a. f a -> Free f a

--- a/src/Control/Monad/Free.purs
+++ b/src/Control/Monad/Free.purs
@@ -40,30 +40,30 @@ data FreeView f a b = Return a | Bind (f b) (b -> Free f a)
 
 data Val
 
-instance freeFunctor :: Functor (Free f) where
+instance functorFree :: Functor (Free f) where
   map k f = f >>= return <<< k
 
-instance freeBind :: Bind (Free f) where
+instance bindFree :: Bind (Free f) where
   bind (Free v s) k = Free v (snoc s (ExpF (unsafeCoerceBind k)))
     where
     unsafeCoerceBind :: forall a b. (a -> Free f b)-> (Val -> Free f Val)
     unsafeCoerceBind = unsafeCoerce
 
-instance freeApplicative :: Applicative (Free f) where
+instance applicativeFree :: Applicative (Free f) where
   pure = fromView <<< Return
 
-instance freeApply :: Apply (Free f) where
+instance applyFree :: Apply (Free f) where
   apply = ap
 
-instance freeMonad :: Monad (Free f)
+instance monadFree :: Monad (Free f)
 
-instance freeMonadTrans :: MonadTrans Free where
+instance monadTransFree :: MonadTrans Free where
   lift = liftF
 
-instance freeMonadRec :: MonadRec (Free f) where
+instance monadRecFree :: MonadRec (Free f) where
   tailRecM k a = k a >>= either (tailRecM k) pure
 
-instance freeMonadEff :: (MonadEff eff f) => MonadEff eff (Free f) where
+instance monadEffFree :: (MonadEff eff f) => MonadEff eff (Free f) where
   liftEff = lift <<< liftEff
 
 -- | Lift an impure value described by the generating type constructor `f` into the free monad.


### PR DESCRIPTION
I know this was sort of covered by #31 before, but this instance would be super useful to have for Halogen.

I understand the point that `f` is not necessarily a `Monad` (or `MonadEff` for that matter), but I’m not so sure I see why it’s a problem to provide the instance for the cases when it is, especially since it’s not possible to define instances like this anywhere else.

We do something similar with the `Monoid` newtypes: provide a bunch of instances for things that the underlying type might not be, but could be.