### PR TITLE
Relax instance requirements for bind/monad

### DIFF
--- a/src/Control/Comonad/Cofree.purs
+++ b/src/Control/Comonad/Cofree.purs
@@ -10,7 +10,7 @@ module Control.Comonad.Cofree
 import Prelude
 
 import Control.Comonad (class Comonad)
-import Control.Alternative (class Alternative, (<|>))
+import Control.Alternative (class Alternative, (<|>), empty)
 import Control.Extend (class Extend)
 import Control.Monad.Trampoline (Trampoline, runTrampoline)
 
@@ -81,8 +81,8 @@ instance applyCofree :: (Apply f) => Apply (Cofree f) where
     h = (head f) (head x)
     t = (<*>) <$> (tail f) <*> (tail x)
 
-instance applicativeCofree :: (Applicative f) => Applicative (Cofree f) where
-  pure a = mkCofree a (pure $ pure a)
+instance applicativeCofree :: (Alternative f) => Applicative (Cofree f) where
+  pure a = mkCofree a empty
 
 instance bindCofree :: (Alternative f) => Bind (Cofree f) where
   bind fa f = loop fa where

--- a/src/Control/Comonad/Cofree.purs
+++ b/src/Control/Comonad/Cofree.purs
@@ -10,8 +10,7 @@ module Control.Comonad.Cofree
 import Prelude
 
 import Control.Comonad (class Comonad)
-import Control.Alt ((<|>))
-import Control.MonadPlus (class MonadPlus)
+import Control.Alternative (class Alternative, (<|>))
 import Control.Extend (class Extend)
 import Control.Monad.Trampoline (Trampoline, runTrampoline)
 
@@ -85,9 +84,9 @@ instance applyCofree :: (Apply f) => Apply (Cofree f) where
 instance applicativeCofree :: (Applicative f) => Applicative (Cofree f) where
   pure a = mkCofree a (pure $ pure a)
 
-instance bindCofree :: (MonadPlus f) => Bind (Cofree f) where
+instance bindCofree :: (Alternative f) => Bind (Cofree f) where
   bind fa f = loop fa where
     loop fa = let fh = f (head fa)
               in mkCofree (head fh) ((tail fh) <|> (loop <$> tail fa))
 
-instance monadCofree :: (MonadPlus f) => Monad (Cofree f)
+instance monadCofree :: (Alternative f) => Monad (Cofree f)


### PR DESCRIPTION
For `Cofree f` to be a monad, you only need `Alternative`, not `MonadPlus`. From [hackage](https://hackage.haskell.org/package/free-4.12.4/docs/Control-Comonad-Cofree.html):

> Furthermore, if the functor f forms a monoid (for example, by being an instance of Alternative), the resulting Comonad is also a Monad. See Monadic Augment and Generalised Shortcut Fusion by Neil Ghani et al., Section 4.3 for more details.

The implementation of `pure` is an infinite loop. This PR also addresses that, and includes an `Alternative` requirement on the `Applicative` instance.