### PR TITLE
Fast hoistFree

### DIFF
--- a/src/Control/Monad/Free.purs
+++ b/src/Control/Monad/Free.purs
@@ -90,7 +90,12 @@ suspendF f = fromView (Bind (unsafeCoerceF (pure f)) unsafeCoerceVal)
 -- | Use a natural transformation to change the generating type constructor of a
 -- | free monad.
 hoistFree :: forall f g. (f ~> g) -> Free f ~> Free g
-hoistFree k = foldFree (liftF <<< k)
+hoistFree k = go
+  where
+  go :: Free f ~> Free g
+  go f = case toView f of
+    Return a -> pure a
+    Bind g i -> fromView (Bind (k g) (go <$> i))
 
 -- | Embed computations in one `Free` monad as computations in the `Free` monad
 -- | for a coproduct type constructor.


### PR DESCRIPTION
`foldFree` has pathological performance in certain cases (in our case lots of nested interpretations). This changes `hoistFree` to work on the underlying view directly instead of going through `foldFree` (essentially giving us map fusion).

In my simple test case, previously it was creating 16,870 binds (losing `MonadRec` and using `resume` resulted in a reduction by half), and with the new `hoistFree` it gets fused into 270 binds.

Please tell me I'm not doing something totally wrong... 😆 