### PR TITLE
Add Eq and Ord instances for Free and Cofree

### DIFF
--- a/src/Control/Comonad/Cofree.purs
+++ b/src/Control/Comonad/Cofree.purs
@@ -83,6 +83,15 @@ explore pair m w =
     step :: f (Free f (a -> b)) -> State (Cofree g a) (Free f (a -> b))
     step ff = state \cof -> pair (map Tuple ff) (tail cof)
 
+instance eqCofree :: (Eq (f (Cofree f a)), Eq a) => Eq (Cofree f a) where
+  eq x y = head x == head y && tail x == tail y
+
+instance ordCofree :: (Ord (f (Cofree f a)), Ord a) => Ord (Cofree f a) where
+  compare x y =
+    case compare (head x) (head y) of
+      EQ -> compare (tail x) (tail y)
+      r -> r
+
 instance functorCofree :: Functor f => Functor (Cofree f) where
   map f = loop where
     loop fa = Cofree (f (head fa)) (_lift loop (_tail fa))

--- a/src/Control/Monad/Free.purs
+++ b/src/Control/Monad/Free.purs
@@ -41,6 +41,12 @@ data FreeView f a b = Return a | Bind (f b) (b -> Free f a)
 
 data Val
 
+instance eqFree :: (Functor f, Eq (f (Free f a)), Eq a) => Eq (Free f a) where
+  eq x y = resume x == resume y
+
+instance ordFree :: (Functor f, Ord (f (Free f a)), Ord a) => Ord (Free f a) where
+  compare x y = compare (resume x) (resume y)
+
 instance freeFunctor :: Functor (Free f) where
   map k f = pure <<< k =<< f
 


### PR DESCRIPTION
These have pretty gross constraints, but without `Eq1` and `Ord1` being in core I don’t think we can do any better.