### PR TITLE
Add MonadFree and ComonadCofree

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,3 +24,43 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+This library makes use of code taken from, or inpired by the following
+libraries. Their LICENSE files follow.
+
+	free, from http://hackage.haskell.org/package/free/
+
+'free' LICENSE file:
+
+	Copyright 2008-2013 Edward Kmett
+
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions
+	are met:
+
+	1. Redistributions of source code must retain the above copyright
+	   notice, this list of conditions and the following disclaimer.
+
+	2. Redistributions in binary form must reproduce the above copyright
+	   notice, this list of conditions and the following disclaimer in the
+	   documentation and/or other materials provided with the distribution.
+
+	3. Neither the name of the author nor the names of his contributors
+	   may be used to endorse or promote products derived from this software
+	   without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+	IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+	ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+	DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+	OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.

--- a/src/Control/Comonad/Cofree/Class.purs
+++ b/src/Control/Comonad/Cofree/Class.purs
@@ -1,0 +1,30 @@
+module Control.Comonad.Cofree.Class
+  ( class ComonadCofree
+  , unwrapCofree
+  ) where
+
+import Prelude
+
+import Control.Comonad (class Comonad)
+import Control.Comonad.Cofree (Cofree, tail)
+import Control.Comonad.Env.Trans (EnvT(..))
+import Control.Comonad.Store.Trans (StoreT(..))
+import Control.Comonad.Traced.Trans (TracedT(..))
+import Data.Monoid (class Monoid)
+import Data.Tuple (Tuple(..))
+
+-- | Based on <http://hackage.haskell.org/package/free/docs/Control-Comonad-Cofree-Class.html>
+class (Functor f, Comonad w) <= ComonadCofree f w | w -> f where
+  unwrapCofree :: forall a. w a -> f (w a)
+
+instance comonadCofreeCofree :: Functor f => ComonadCofree f (Cofree f) where
+  unwrapCofree = tail
+
+instance comonadCofreeEnvT :: (Functor f, ComonadCofree f w) => ComonadCofree f (EnvT e w) where
+  unwrapCofree (EnvT (Tuple e wa)) = map (\x -> EnvT (Tuple e x)) (unwrapCofree wa)
+
+instance comonadCofreeStoreT :: (Functor f, ComonadCofree f w) => ComonadCofree f (StoreT s w) where
+  unwrapCofree (StoreT (Tuple wsa s)) = map (\x -> StoreT (Tuple x s)) (unwrapCofree wsa)
+
+instance comonadCofreeTracedT :: (Functor f, ComonadCofree f w, Monoid m) => ComonadCofree f (TracedT m w) where
+  unwrapCofree (TracedT wma) = map TracedT (unwrapCofree wma)

--- a/src/Control/Comonad/Cofree/Class.purs
+++ b/src/Control/Comonad/Cofree/Class.purs
@@ -10,7 +10,6 @@ import Control.Comonad.Cofree (Cofree, tail)
 import Control.Comonad.Env.Trans (EnvT(..))
 import Control.Comonad.Store.Trans (StoreT(..))
 import Control.Comonad.Traced.Trans (TracedT(..))
-import Data.Monoid (class Monoid)
 import Data.Tuple (Tuple(..))
 
 -- | Based on <http://hackage.haskell.org/package/free/docs/Control-Comonad-Cofree-Class.html>

--- a/src/Control/Monad/Free/Class.purs
+++ b/src/Control/Monad/Free/Class.purs
@@ -11,7 +11,6 @@ import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.Monad.Reader.Trans (ReaderT(..), runReaderT)
 import Control.Monad.State.Trans (StateT(..), runStateT)
 import Control.Monad.Writer.Trans (WriterT(..), runWriterT)
-import Data.Monoid (class Monoid)
 
 -- | Based on <http://hackage.haskell.org/package/free/docs/Control-Monad-Free-Class.html>
 class Monad m <= MonadFree f m | m -> f where

--- a/src/Control/Monad/Free/Class.purs
+++ b/src/Control/Monad/Free/Class.purs
@@ -1,0 +1,36 @@
+module Control.Monad.Free.Class
+  ( class MonadFree
+  , wrapFree
+  ) where
+
+import Prelude
+
+import Control.Monad.Except.Trans (ExceptT(..), runExceptT)
+import Control.Monad.Free (Free, liftF)
+import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
+import Control.Monad.Reader.Trans (ReaderT(..), runReaderT)
+import Control.Monad.State.Trans (StateT(..), runStateT)
+import Control.Monad.Writer.Trans (WriterT(..), runWriterT)
+import Data.Monoid (class Monoid)
+
+-- | Based on <http://hackage.haskell.org/package/free/docs/Control-Monad-Free-Class.html>
+class Monad m <= MonadFree f m | m -> f where
+  wrapFree :: forall a. f (m a) -> m a
+
+instance monadFreeFree :: MonadFree f (Free f) where
+  wrapFree = join <<< liftF
+
+instance monadFreeReaderT :: (Functor f, MonadFree f m) => MonadFree f (ReaderT r m) where
+  wrapFree f = ReaderT \r -> wrapFree (map (\rt -> runReaderT rt r) f)
+
+instance monadFreeStateT :: (Functor f, MonadFree f m) => MonadFree f (StateT s m) where
+  wrapFree f = StateT \s -> wrapFree (map (\st -> runStateT st s) f)
+
+instance monadFreeWriterT :: (Functor f, MonadFree f m, Monoid w) => MonadFree f (WriterT w m) where
+  wrapFree f = WriterT (wrapFree (map runWriterT f))
+
+instance monadFreeMaybeT :: (Functor f, MonadFree f m) => MonadFree f (MaybeT m) where
+  wrapFree f = MaybeT (wrapFree (map runMaybeT f))
+
+instance monadFreeExceptT :: (Functor f, MonadFree f m) => MonadFree f (ExceptT e m) where
+  wrapFree f = ExceptT (wrapFree (map runExceptT f))


### PR DESCRIPTION
I need this for some comonads-as-spaces work I'm doing in `purescript-pairings`.

I think we ought to discuss how to properly give attribution for ported Haskell code before we merge this, since `free` is BSD-3 licensed which would mean switching this repo over to BSD-3 too, and then adding a section to the license file. Thoughts?