### PR TITLE
Adds semigroup and monoid instances for Cofree

### DIFF
--- a/src/Control/Comonad/Cofree.purs
+++ b/src/Control/Comonad/Cofree.purs
@@ -119,6 +119,12 @@ exploreM pair m w =
     eval :: forall x y. Tuple (x -> y) (Cofree g x) -> y
     eval (Tuple f cof) = f (extract cof)
 
+instance semigroupCofree :: (Functor f, Apply f, Semigroup a) => Semigroup (Cofree f a) where
+  append x y = deferCofree \_ -> Tuple (head x <> head y) (append <$> tail x <*> tail y)
+
+instance monoidCofree :: (Applicative f, Monoid a) => Monoid (Cofree f a) where
+  mempty = deferCofree \_ -> Tuple mempty (pure mempty)
+
 instance eqCofree :: (Eq1 f, Eq a) => Eq (Cofree f a) where
   eq x y = head x == head y && tail x `eq1` tail y
 

--- a/src/Control/Comonad/Cofree.purs
+++ b/src/Control/Comonad/Cofree.purs
@@ -119,7 +119,7 @@ exploreM pair m w =
     eval :: forall x y. Tuple (x -> y) (Cofree g x) -> y
     eval (Tuple f cof) = f (extract cof)
 
-instance semigroupCofree :: (Functor f, Apply f, Semigroup a) => Semigroup (Cofree f a) where
+instance semigroupCofree :: (Apply f, Semigroup a) => Semigroup (Cofree f a) where
   append x y = deferCofree \_ -> Tuple (head x <> head y) (append <$> tail x <*> tail y)
 
 instance monoidCofree :: (Applicative f, Monoid a) => Monoid (Cofree f a) where


### PR DESCRIPTION
**Description of the change**

The purpose of the pull request is to decrease the burden on library writers of creating newtypes for `Cofree` when they want semigroup and monoid instances. For example, in https://github.com/mikesol/purescript-wags-lib/blob/main/src/WAGS/Lib/Rate.purs and many other files in that project, custom Semigroup and Monoid instances are created using this pattern, which leads to lots of code duplication.

From my testing, it seems that these follow the `Semigroup` and `Monoid` laws.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
