### PR TITLE
Adds recastCofree

### DIFF
--- a/src/Control/Comonad/Cofree.purs
+++ b/src/Control/Comonad/Cofree.purs
@@ -60,6 +60,16 @@ tail (Cofree c) = snd (force c)
 hoistCofree :: forall f g. Functor f => (f ~> g) -> Cofree f ~> Cofree g
 hoistCofree nat (Cofree c) = Cofree (map (nat <<< map (hoistCofree nat)) <$> c)
 
+-- | Recasts a cofree comonad's functor from `f` to `g` by
+-- | passing a function in which `g` can annihilate `f`.
+recastCofree
+  :: forall f g a
+   . Functor f
+  => (forall z. (Cofree f a -> z) -> f (Cofree f a) -> g z)
+  -> Cofree f a
+  -> Cofree g a
+recastCofree w (Cofree c) = Cofree ((map <<< map) (w (recastCofree w)) c)
+
 -- | This signature is deprecated and will be replaced by `buildCofree` in a
 -- | future release.
 unfoldCofree


### PR DESCRIPTION
**Description of the change**

Recast cofree is useful  in cases where one wants to change the functor of a `Cofree` but the natural transformation `f ~> g` required in `hoistCofree` is too restrictive. This allows `g` to peek on the inside of `f (Cofree f a)`.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
