### PR TITLE
Adds FunctorWithIndex instance to Cofree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+- Added a `FunctorWithIndex` instance for `Cofree` (#118 by @mikesol)
+
 Bugfixes:
 
 Other improvements:

--- a/src/Control/Comonad/Cofree.purs
+++ b/src/Control/Comonad/Cofree.purs
@@ -22,6 +22,7 @@ import Control.Monad.Free (Free, runFreeM)
 import Control.Monad.Rec.Class (class MonadRec)
 import Control.Monad.State (State, StateT(..), runState, runStateT, state)
 import Data.Eq (class Eq1, eq1)
+import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Foldable (class Foldable, foldr, foldl, foldMap)
 import Data.Lazy (Lazy, force, defer)
 import Data.Ord (class Ord1, compare1)
@@ -144,6 +145,11 @@ instance functorCofree :: Functor f => Functor (Cofree f) where
   map f = loop
     where
     loop (Cofree fa) = Cofree ((\(Tuple a b) -> Tuple (f a) (loop <$> b)) <$> fa)
+
+instance functorWithIndexCofree :: Functor f => FunctorWithIndex Int (Cofree f) where
+  mapWithIndex f = loop 0
+    where
+    loop n (Cofree fa) = Cofree ((\(Tuple a b) -> Tuple (f n a) (loop (n + 1) <$> b)) <$> fa)
 
 instance foldableCofree :: Foldable f => Foldable (Cofree f) where
   foldr f = flip go


### PR DESCRIPTION
**Description of the change**

Adds `FunctorWithIndex` to `Cofree`. This allows a counter to be bolted on to any cofree comonad.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
